### PR TITLE
Bug Fixes, TinyMCE Workaround, 1 New Feature, Removed Functions From Global NS, Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ $.fn.setDirty() will set the provided element as dirty
 $.fn.cleanDirty() will mark the provided form as clean
 	$('form#accountform').cleanDirty();
 
-$.DirtyForms.isDeciding() will return true if the dialog has fired and neither decidingCancel(e) or decidingContinue(e) has yet been called
+$.DirtyForms.decidingContinue() should be called from the dialog to refire the event and continue following the link or button that was clicked. An event object is required to be passed as a parameter.
+	$.DirtyForms.decidingContinue(event)
+	
+$.DirtyForms.decidingCancel() should be called from the dialog to indicate not to move on to the page of the button or link that was clicked. An event object is required to be passed as a parameter.
+	$.DirtyForms.decidingCancel(event)
+
+$.DirtyForms.isDeciding() will return true if the dialog has fired and neither $.DirtyForms.decidingCancel() or $.DirtyForms.decidingContinue() has yet been called
 	if($.DirtyForms.isDeciding())
 	
 Helpers
@@ -125,8 +131,8 @@ fire : function(message, title){
 },
 // Bind binds the continue and cancel functions to the correct links
 bind : function(){
-	$('#facebox .cancel, #facebox .close').click(decidingCancel);
-	$('#facebox .continue').click(decidingContinue);
+	$('#facebox .cancel, #facebox .close').click($.DirtyForms.decidingCancel);
+	$('#facebox .continue').click($.DirtyForms.decidingContinue);
 	$(document).bind('decidingcancelled.dirtyform', function(){
 		$(document).trigger('close.facebox');
 	});				
@@ -151,9 +157,9 @@ refire : function(content){
 	}
 ```
 
-fire accepts a message and title, and is responsible for creating the modal dialog. Note the two classes on each link. In the binddialog method you will see that we bind the 'decidingCancel' method to the .cancel link and the .close link, and we bind 'decidingContinue' to the .continue link. You must bind both decidingCancel and decidingContinue in the bindDialog method.
+fire accepts a message and title, and is responsible for creating the modal dialog. Note the two classes on each link. In the binddialog method you will see that we bind the '$.DirtyForms.decidingCancel' method to the .cancel link and the .close link, and we bind '$.DirtyForms.decidingContinue' to the .continue link. You must bind both $.DirtyForms.decidingCancel and $.DirtyForms.decidingContinue in the bindDialog method.
 
-If the dialog has an extra action (such as a close button or closes as a result of the ESC key) and you need a catch-all decision when the dialog is closed (such as the case with jQueryUI's 'dialogclose' event), the $.DirtyForms.isDeciding() method can be called to check whether it is safe to call decidingCancel(e) explicitly. Here is an example of setting up a jQueryUI dialog with dirtyForms:
+If the dialog has an extra action (such as a close button or closes as a result of the ESC key) and you need a catch-all decision when the dialog is closed (such as the case with jQueryUI's 'dialogclose' event), the $.DirtyForms.isDeciding() method can be called to check whether it is safe to call $.DirtyForms.decidingCancel() explicitly. Here is an example of setting up a jQueryUI dialog with dirtyForms:
 
 ```javascript
 $.DirtyForms.dialog = {
@@ -163,7 +169,7 @@ $.DirtyForms.dialog = {
 		$('#unsavedChanges').html(message);
 	},
 	refire: function(content) {
-		$('#unsavedChanges').dialog();	
+		return false;
 	},
 	stash: function() {
 		return false;
@@ -174,14 +180,14 @@ $.DirtyForms.dialog = {
 				{
 					text: "Go Back",
 					click: function(e) {
-						decidingCancel(e);
+						$.DirtyForms.decidingCancel(e);
 						$(this).dialog('close');
 					}
 				},
 				{
 					text: "Continue",
 					click: function(e) {
-						decidingContinue(e);
+						$.DirtyForms.decidingContinue(e);
 						$(this).dialog('close');
 					}
 				}
@@ -190,7 +196,7 @@ $.DirtyForms.dialog = {
 			// Check whether a decision has been made, if not default
 			// to decidingCancel()
 			if ($.DirtyForms.isDeciding()) {
-				decidingCancel(e);
+				$.DirtyForms.decidingCancel(e);
 			}
 		});
 	}

--- a/helpers/tinymce.js
+++ b/helpers/tinymce.js
@@ -11,10 +11,10 @@ if (typeof $.fn.livequery == 'undefined') throw("Live Query plugin Required");
 				// Search for all tinymce elements inside the given form
 				$(form).find(':tinymce').each(function(){
 
-					dirtylog('Checking node ' + $(this).attr('id'));
+					$.DirtyForms.dirtylog('Checking node ' + $(this).attr('id'));
 					if($(this).tinymce().isDirty()){
 						isDirty = true;
-						dirtylog('Node was totally dirty.');
+						$.DirtyForms.dirtylog('Node was totally dirty.');
 						return true;
 					}
 				});	

--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -72,6 +72,18 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 			
 			isDeciding : function(){
 				return settings.deciding;
+			},
+			
+			decidingContinue : function(e){
+				decidingContinue(e);
+			},
+			
+			decidingCancel : function(e){
+				decidingCancel(e);
+			},
+			
+			dirtylog : function(msg){
+				dirtylog(msg);
 			}
 		}
 	});
@@ -160,7 +172,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		focused: {"element": false, "value": false}
 	}, $.DirtyForms);
 
-	onFocus = function() {
+	var onFocus = function() {
 		element = $(this);
 		if (focusedIsDirty()) {
 			element.setDirty();
@@ -168,7 +180,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		settings.focused['element'] = element;
 		settings.focused['value']	= elementValue(element);
 	}
-	focusedIsDirty = function() {
+	var focusedIsDirty = function() {
 		/** Check, whether the value of focused element has changed */
 		return settings.focused["element"] &&
 			(elementValue(settings.focused["element"]) !== settings.focused["value"]);
@@ -190,7 +202,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		}
 	}
 
-	dirtylog = function(msg){
+	var dirtylog = function(msg){
 		if(!$.DirtyForms.debug) return;
 		msg = "[DirtyForms] " + msg;
 		settings.hasFirebug ?
@@ -199,7 +211,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 				window.console.log(msg) :
 				alert(msg);
 	}
-	bindExit = function(){
+	var bindExit = function(){
 		if(settings.exitBound) return;
 		$('a').live('click',aBindFn);
 		$('form').live('submit',formBindFn);
@@ -207,16 +219,16 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		settings.exitBound = true;
 	}
 
-	aBindFn = function(ev){
+	var aBindFn = function(ev){
 		 bindFn(ev);
 	}
 
-	formBindFn = function(ev){
+	var formBindFn = function(ev){
 		settings.currentForm = this;
 		bindFn(ev);
 	}
 
-	beforeunloadBindFn = function(ev){
+	var beforeunloadBindFn = function(ev){
 		var result = bindFn(ev);
 
 		if(result && settings.doubleunloadfix != true){
@@ -242,7 +254,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		}
 	}
 
-	bindFn = function(ev){
+	var bindFn = function(ev){
 		dirtylog('Entering: Leaving Event fired, type: ' + ev.type + ', element: ' + ev.target + ', class: ' + $(ev.target).attr('class') + ' and id: ' + ev.target.id);
 
 		if(ev.type == 'beforeunload' && settings.doubleunloadfix){
@@ -321,7 +333,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		settings.dialog.bind();
 	}
 
-	decidingCancel = function(ev){
+	var decidingCancel = function(ev){
 		ev.preventDefault();
 		$(document).trigger('decidingcancelled.dirtyforms');
 		if(settings.dialog !== false && settings.dialogStash !== false)
@@ -334,7 +346,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		settings.deciding = settings.currentForm = settings.decidingEvent = false;
 	}
 
-	decidingContinue = function(ev){
+	var decidingContinue = function(ev){
 		window.onbeforeunload = null; // fix for chrome
 		ev.preventDefault();
 		settings.dialogStash = false;
@@ -343,7 +355,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		settings.deciding = settings.currentForm = settings.decidingEvent = false;
 	}
 
-	clearUnload = function(){
+	var clearUnload = function(){
 		// I'd like to just be able to unbind this but there seems
 		// to be a bug in jQuery which doesn't unbind onbeforeunload
 		dirtylog('Clearing the beforeunload event');
@@ -351,7 +363,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		window.onbeforeunload = null;
 	}
 
-	refire = function(e){
+	var refire = function(e){
 		$(document).trigger('beforeRefire.dirtyforms');
 		switch(e.type){
 			case 'click':


### PR DESCRIPTION
I broke all of this into separate commits so if you wish you can pick and choose.

Fixes:
1. Fix for issue #22, message not showing in IE9. It turned out the logic seems correct in bindFn(), it just needed to ensure the datatype was string before returning to the browser in beforeunloadBindFn().
2. The state of checkboxes, radio buttons, and multi-select lists wasn't being checked properly, so they were being ignored. A function named elementValue() was added to encapsulate the logic of returning the correct value to track whether the element is dirty.
3. Copyright notice states that it must be included, but when minified, it disappeared. Added correct comment opening tag to preserve the comment when compressed.

TinyMCE Workaround:

The :tinymce selector appears to be broken (in jquery.tinymce.js). When no textareas with the appropriate class are on the form, it throws an exception rather than silently returning an empty collection. A wrapper method named formHasTinyMCE() was added to ensure a dirty state (rather than an error) is returned from the tinymce helper in this case.

New Feature:

The isDeciding() method was added to allow the calling code to check whether it has made a decision so it won't accidentally do it again. This came in handy for the "X" button and ESC key in jQueryUI dialog, which cannot be directly bound to, but instead you have to resort to a catch-all 'dialogclose' event, which is called whether a decision was made or not.

Spring Cleaning:

Made all functions under the section titled "Private Properties and Methods" private. This was accomplished by making them into function variables with local scope (using var before the function name). There might be a better way than that, but it did the trick.

This change was made to ensure that we don't see unpredictable issues when code that uses one of the same function names is used elsewhere in the page.

Note that this is a breaking change for anything that is currently using the following methods from outside of the library:

decidingCancel
decidingContinue
dirtylog

There are other methods included as well, but as they are undocumented I am not including them in this list.

Any code calling these must be migrated to the following namespaced accessor methods:

$.DirtyForms.decidingCancel
$.DirtyForms.decidingContinue
$.DirtyForms.dirtylog

Note that

Documentation:

Updated documentation to incude new features, some previously undocumented features, a spelling error, as well as provided a sample on how to use with jQueryUI (it took some head scratching to figure out with the current document).
