### PR TITLE
Fix for issue #28 deferred execution of decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Prerequisites
 ---------------------------------
 Must have jQuery version 1.4.2 or higher. 
 
-When using the TinyMCE helper, the [livequery plugin](https://github.com/brandonaaron/livequery/downloads "livequery plugin") is required, as well as the [jQuery plugin for TinyMCE](http://www.tinymce.com/download/download.php "jQuery plugin for TinyMCE").
+When using the TinyMCE helper, the [jQuery plugin for TinyMCE](http://www.tinymce.com/download/download.php "jQuery plugin for TinyMCE") is required.
 
 **Note:** There are [known compatibility issues](http://bugs.jquery.com/ticket/11527) between jQuery 1.7.2 and higher and TinyMCE versions lower than 3.5b3. These issues can cause the dialog continue function to fail in dirtyForms.
 
@@ -127,7 +127,16 @@ Dirty Forms was created because the similar plugins that existed were not flexib
 
 This is useful when you're using replacement inputs or textarea, such as with tinymce. To enable the tinymce helper, simply include the helpers/tinymce.js file.
 
-Currently only the **isDirty(node)** and **setClean(node)** methods are available for use within helpers. The node parameter is typically an individual form element. To respect the way jQuery selectors work, all children of the node as well as the node itself should have your custom **isDirty()** and **setClean()** logic applied.
+**MEMBERS (All Optional)**
+
+**isDirty(node)** - method - Should return the dirty status of the helper.
+
+**setClean(node)** - method - Should reset the dirty status of the helper so *isDirty(node)* will return false the next time it is called.
+
+**ignoreAnchorSelector** - property - A jQuery selector of any anchor elements to exclude from activating the dialog. Non-anchors will be ignored. This works similarly to putting the ignoreClass on a specific anchor, but will always ignore the anchors if your helper is included.
+
+
+The node parameter is typically an individual form element. To respect the way jQuery selectors work, all children of the node as well as the node itself should have your custom **isDirty()** and **setClean()** logic applied.
 
 **IMPORTANT**: Support for the former *isNodeDirty(node)* method has been deprecated. Please update any custom helpers to use **isDirty(node)**. This change was made to make helpers easier to understand and use.
 
@@ -137,6 +146,8 @@ Currently only the **isDirty(node)** and **setClean(node)** methods are availabl
 (function($){
 	// Create a new object, with an isDirty method
 	var alwaysDirty = {
+		// Ignored anchors will not activate the dialog
+		ignoreAnchorSelector : '.editor a, a.toolbar',
 		isDirty : function(node){
 			// Perform dirty check on a given node (usually a form element)
 			return true;

--- a/helpers/tinymce.js
+++ b/helpers/tinymce.js
@@ -1,9 +1,9 @@
 // TinyMCE helper, checks to see if TinyMCE editors in the given form are dirty
 
 (function($){
-if (typeof $.fn.livequery == 'undefined') throw("Live Query plugin Required");
 	// Create a new object, with an isDirty method
 	var tinymce = {
+		ignoreAnchorSelector : '.mceEditor a,.mceMenu a',
 		isDirty : function(form){
 			var isDirty = false;
 			if (formHasTinyMCE(form)) {
@@ -50,7 +50,4 @@ if (typeof $.fn.livequery == 'undefined') throw("Live Query plugin Required");
 	//      This is no longer needed, but kept here to remind me.
 	//      tinyMCE.triggerSave();
 	//});
-	$('.mceEditor a, .mceEditor span, .mceEditor img, .mceMenu a, .mceMenu span').livequery(function(){
-		$(this).addClass($.DirtyForms.ignoreClass);
-	});
 })(jQuery);

--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -258,6 +258,7 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 				window.console.log(msg) :
 				alert(msg);
 	}
+	
 	var bindExit = function(){
 		if(settings.exitBound) return;
 
@@ -287,9 +288,23 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 
 		settings.exitBound = true;
 	}
+	
+	var getIgnoreAnchorSelector = function(){
+		var result = '';
+		$.each($.DirtyForms.helpers, function(key,obj){
+			if("ignoreAnchorSelector" in obj){
+				if (result.length > 0) { result += ','; }
+				result += obj.ignoreAnchorSelector;
+			}
+		});
+		return result;
+	}
 
 	var aBindFn = function(ev){
-		 bindFn(ev);
+		// Filter out any anchors the helpers wish to exclude
+		if (!$(this).is(getIgnoreAnchorSelector())) {
+			bindFn(ev);
+		}
 	}
 
 	var formBindFn = function(ev){


### PR DESCRIPTION
The title and issue explains all of it except that I also added all of the triggers to the documetaion, although it was difficult to describe when each trigger is fired.

Anyway, I decided to leave the $.DirtyForms.isDeciding(), $.DirtyForms.decidingCancel() and $.DirtyForms.decidingContinue() methods as _not_ deprecated because it makes this plugin more flexible (although the naming is a bit confusing). With the 2 code examples in the documentation, there will hopefully be enough clarity to use them the right way.

I wanted to find a way to indicate that these 2 methods were related to each other and the other 3 are related to each other, and the naming convention was pretty much it. However, it would probably be better if there weren't both a **decisionContinue** property and a **decidingContinue()** method that are not related. I suppose the new property could just be **continue** and the new method called **commitDecision()** but then it is not clear that these 2 are related. Naming the property **decision** makes it clearer exept for it doesn't indicate what the true or false state mean. That is why I settled on **decisionContinue** and **decisionCommit**.
