### PR TITLE
Added an event to be fired when leaving the page regardless of whether form was dirty or clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ Triggers
 
 **beforeRefire.dirtyforms**: Raised before the original event is refired after a user chooses to leave the page.
 
+**beforeunload.dirtyforms**: Non-cancelable event, raised prior leaving the page which may happen either as result of user selection if forms were dirty, or due to a normal page exit of no changes were made.
+
 
 You can attach callbacks to the **decidingcancelled.dirtyforms** and **decidingcontinued.dirtyforms** custom events. These events are called when the cancel, or continue method on the modal dialog is called (when the user clicks either continue, or cancel).
 

--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -470,10 +470,12 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		dirtylog('Clearing the beforeunload event');
 		$(window).unbind('beforeunload', beforeunloadBindFn);
 		window.onbeforeunload = null;
+		$(document).trigger('beforeunload.dirtyforms');
 	}
 
 	var refire = function(e){
 		$(document).trigger('beforeRefire.dirtyforms');
+		$(document).trigger('beforeunload.dirtyforms');
 		switch(e.type){
 			case 'click':
 				dirtylog("Refiring click event");


### PR DESCRIPTION
Because DirtyForms overrides usual beforeunload event flow, it is no longer possible to use beforeunload to perform some last second cleanup (release object locks that user might have; log something; etc). This patch adds beforeunload.dirtyforms event to do just that.
