### PR TITLE
Checking for href's undefined value

### DIFF
--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -484,7 +484,9 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 				if(!event.isDefaultPrevented()){
 					var anchor = $(e.target).closest('[href]');
 					dirtylog('Sending location to ' + anchor.attr('href'));
-					location.href = anchor.attr('href');
+					if (anchor.attr('href')!=undefined) {
+						location.href = anchor.attr('href');
+					}
 					return;
 				}
 				break;


### PR DESCRIPTION
If this check is not present and if any anchor tag does not has href attribute (which its not there in dataTables plugin) then the page was being redirected to "/undefined".
