### PR TITLE
Fix wrong page leave on click a tag without href data

### DIFF
--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -271,17 +271,17 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 		
 		// For jQuery 1.7+, use on()
 		if (typeof $(document).on === 'function') {
-			$(document).on('click','a',aBindFn);
+			$(document).on('click','a[href]',aBindFn);
 			$(document).on('submit','form',formBindFn);
 			if (settings.watchParentDocs && inIframe) {
-				$(top.document).on('click','a',aBindFn);
+				$(top.document).on('click','a[href]',aBindFn);
 				$(top.document).on('submit','form',formBindFn);
 			}
 		} else { // For jQuery 1.4.2 - 1.7, use delegate()
-			$(document).delegate('a','click',aBindFn);
+			$(document).delegate('a[href]','click',aBindFn);
 			$(document).delegate('form','submit',formBindFn);
 			if (settings.watchParentDocs && inIframe) {
-				$(top.document).delegate('a','click',aBindFn);
+				$(top.document).delegate('a[href]','click',aBindFn);
 				$(top.document).delegate('form','submit',formBindFn);
 			}
 		}
@@ -344,10 +344,6 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 	}
 
 	var bindFn = function(ev){
-		if(ev.currentTarget.tagName == "A" && !ev.currentTarget.href) {
-	        	return false;
-	    	}
-	    
 		dirtylog('Entering: Leaving Event fired, type: ' + ev.type + ', element: ' + ev.target + ', class: ' + $(ev.target).attr('class') + ' and id: ' + ev.target.id);
 
 		if(ev.type == 'beforeunload' && settings.doubleunloadfix){


### PR DESCRIPTION
If form contains field(s) with jquery.ui.autocomplete, autocomplete generate html a tags with empty href attribute. If you select item from list dirty popup showing.
