### PR TITLE
Don't trigger when no href included on link

### DIFF
--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -306,8 +306,10 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 	}
 
 	var aBindFn = function(ev){
+		var a = $(this);
+		
 		// Filter out any anchors the helpers wish to exclude
-		if (!$(this).is(getIgnoreAnchorSelector())) {
+		if (!a.is(getIgnoreAnchorSelector()) && typeof a.attr('href') != 'undefined') {
 			bindFn(ev);
 		}
 	}


### PR DESCRIPTION
When using the dirtyforms plugin with Bootstrap's datepicker control I noticed that the next and previous buttons to switch between months causes the modal to display. It makes sense to skip links where there is no href as the user will not be leaving the page on clicking them.
