### PR TITLE
Add bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,8 @@
     "lib",
     "helpers",
     "README.md"
-  ]
+  ],
+  "dependencies": {
+    "lib/facebox": "git://github.com/snikch/facebox"
+  },
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "README.md"
   ],
   "dependencies": {
-    "lib/facebox": "git://github.com/nickcoyne/facebox"
+    "lib/facebox": "git@github.com/nickcoyne/facebox.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "README.md"
   ],
   "dependencies": {
-    "lib/facebox": "git@github.com/nickcoyne/facebox.git"
+    "lib/facebox": "git@github.com:nickcoyne/facebox.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "README.md"
   ],
   "dependencies": {
-    "facebox": "https://github.com/nickcoyne/facebox.git"
+    "facebox": "https://github.com/nickcoyne/facebox.git#cssified"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "README.md"
   ],
   "dependencies": {
-    "lib/facebox": "git://github.com/snikch/facebox"
+    "lib/facebox": "git://github.com/nickcoyne/facebox"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "jquery.dirtyforms",
+  "main": "jquery.dirtyforms.js",
+  "version": "1.0.0",
+  "homepage": "https://github.com/nickcoyne/jquery.dirtyforms",
+  "authors": [
+    "Mal Curtis <mal@mal.co.nz>"
+  ],
+  "description": "This is a bower enabled fork of jquery.dirtyforms",
+  "keywords": [
+    "dirty",
+    "forms"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "lib",
+    "helpers",
+    "README.md"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
     "README.md"
   ],
   "dependencies": {
-    "lib/facebox": "git@github.com:nickcoyne/facebox.git"
+    "facebox": "https://github.com/nickcoyne/facebox.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,5 +24,5 @@
   ],
   "dependencies": {
     "lib/facebox": "git://github.com/snikch/facebox"
-  },
+  }
 }


### PR DESCRIPTION
I've added a bower.json file so that the plugin can be installed via bower. There is another fork at https://github.com/strongholder/jquery.dirtyforms, but they haven't been keeping up to date with your original. I've borrowed the bower.json file directly from that fork, updating the author to be the correct (original) author.