### PR TITLE
added a callback to settings for when form is checked

### DIFF
--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -234,20 +234,30 @@ if (typeof jQuery == 'undefined') throw ("jQuery Required");
 
 	var onReset = function() {
 		$(this).parents('form').dirtyForms('setClean');
+		if(settings.onFormCheck) {
+			settings.onFormCheck();
+		}
 	}
 
 	var onSelectionChange = function() {
 		if ($(this).hasClass($.DirtyForms.ignoreClass)) return;
 		$(this).dirtyForms('setDirty');
+		if(settings.onFormCheck) {
+			settings.onFormCheck();
+		}
 	}
 
 	var onFocus = function() {
 		element = $(this);
 		if (focusedIsDirty()) {
 			settings.focused['element'].dirtyForms('setDirty');
+			if(settings.onFormCheck) {
+				settings.onFormCheck();
+			}
 		}
 		settings.focused['element'] = element;
 		settings.focused['value']	= element.val();
+		
 	}
 	var focusedIsDirty = function() {
 		// Check, whether the value of focused element has changed


### PR DESCRIPTION
I added an optional callback to settings called "onFormCheck". The use case I had in mind is to show a message to the user *before* they attempt to navigate away telling them that their form is dirty. The callback is optional, it shouldn't break any existing functionality.

Example usage:

	<script type="text/javascript">
		$(function() {
			var myCallback = function() {
				if($("form").dirtyForms("isDirty")) {
					$("#message").html("Your form is dirty.");
				} else {
					$("#message").html("Your form is clean.");
				}
			};
		
			$.DirtyForms.onFormCheck = myCallback;
			$("form").dirtyForms();
		});
	</script>
