### PR TITLE
Improved performance dirty selector

### DIFF
--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -151,7 +151,7 @@ License MIT
             if (!$(a).hasClass($.DirtyForms.dirtyClass)) {
                 return false;
             }
-            return $(a).not(':dirtyignored').length > 0;
+            return $(a).not(':dirtyignored').hasClass($.DirtyForms.dirtyClass);
         },
         dirtylistening: function (a) {
             return $(a).hasClass($.DirtyForms.listeningClass);

--- a/jquery.dirtyforms.js
+++ b/jquery.dirtyforms.js
@@ -148,7 +148,10 @@ License MIT
     // Custom selectors $('form:dirty')
     $.extend($.expr[":"], {
         dirty: function (a) {
-            return $(a).not(':dirtyignored').hasClass($.DirtyForms.dirtyClass);
+            if (!$(a).hasClass($.DirtyForms.dirtyClass)) {
+                return false;
+            }
+            return $(a).not(':dirtyignored').length > 0;
         },
         dirtylistening: function (a) {
             return $(a).hasClass($.DirtyForms.listeningClass);


### PR DESCRIPTION
A rescan (asp.net updatepanel) would take 7-8 seconds to complete. For every field the dirty selector is used on the form element and the dirty selector uses the dirtyignored selector which is quite heavy. Changed the dirty selector to check for the dirty class first, then only check for dirtyignored on dirty fields.